### PR TITLE
Make binary name match the installed plugin name

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -1,12 +1,13 @@
 load(":release.bzl", "multi_platform_binaries", "release")
 
 multi_platform_binaries(
-    name = "plugin",
+    # This name is chosen to match what we tell users to install in .aspectplugins:
+    # - name: hello-world
+    name = "hello-world",
     embed = ["//:aspect-cli-plugin-template_lib"],
-    prefix = "plugin-",
 )
 
 release(
     name = "release",
-    targets = [":plugin"],
+    targets = [":hello-world"],
 )


### PR DESCRIPTION
This convention simplifies user configuration, since the CLI will be able to predict the download location of the binary.