### PR TITLE
doc: break out developer doc from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+## Developing
+
+To try the plugin, first check that you have the most recent [aspect cli release](https://github.com/aspect-build/aspect-cli/releases) installed.
+
+First build the plugin from source:
+
+```bash
+% bazel build ...
+```
+
+Note that the `.aspect/cli/plugins.yaml` file has a reference to the path under `bazel-bin` where the plugin binary was just written.
+On the first build, you'll see a warning printed that the plugin doesn't exist at this path.
+This is just the development flow for working on plugins; users will reference the plugin's releases which are downloaded for them automatically.
+
+Now just run `aspect`. You should see that `hello-world` appears in the help output. This shows that our plugin was loaded and contributed a custom command to the CLI.
+
+```
+Usage:
+  aspect [command]
+
+Custom Commands from Plugins:
+  hello-world        Print 'Hello World!' to the command line.
+```
+
+## Releasing
+
+Just push a tag to this GitHub repo.
+The actions integration will create a release.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Template for aspect-cli plugins
+# Template: aspect-cli plugin in Go
 
-This repo provides the fastest way to make a plugin for the [aspect cli].
+This repo provides the fastest way to make a plugin for the [aspect cli](https://aspect.build/cli).
 
 It contains a plugin written in Go, with a GitHub actions CI/CD pipeline to release it.
 
-More details about aspect cli plugins is on the [plugin documentation].
+More details about aspect cli plugins is on the [plugin documentation](https://docs.aspect.build/aspect-build/aspect-cli/5.0.3/docs/help/topics/plugins.html)
 
 ## Instructions
 
@@ -14,7 +14,8 @@ Then in your repo...
 1. Find-and-replace `hello-world` with your plugin name.
 1. Find-and-replace `github.com/aspect-build/aspect-cli-plugin-template` with the name of your Go module. See <https://go.dev/doc/modules/developing>
 1. Start coding on your features!
-1. Delete everything above the SNIP line below, and replace it with info about your plugin. Consider showing off your new Bazel behavior with a little animated demo of your terminal! We highly recommend [asciinema](https://asciinema.org).
+1. Delete everything above the SNIP line below, and replace it with info about your plugin.
+1. Want to share your plugin with other developers? Consider adding it to the plugin catalog, by sending a PR editing the `plugins.json` file located in the public [Aspect CLI plugins registry](https://github.com/aspect-build/aspect-cli/tree/main/docs/plugins).
 
 ---------- %<  SNIP %< ------------
 
@@ -22,36 +23,6 @@ Then in your repo...
 
 This is a plugin for the Aspect CLI.
 
-## Developing
+## Demo
 
-To try the plugin, first check that you have the most recent [aspect cli release] installed.
-
-First build the plugin from source:
-
-```bash
-% bazel build ...
-```
-
-Note that the `.aspect/cli/plugins.yaml` file has a reference to the path under `bazel-bin` where the plugin binary was just written.
-On the first build, you'll see a warning printed that the plugin doesn't exist at this path.
-This is just the development flow for working on plugins; users will reference the plugin's releases which are downloaded for them automatically.
-
-Now just run `aspect`. You should see that `hello-world` appears in the help output. This shows that our plugin was loaded and contributed a custom command to the CLI.
-
-```
-Usage:
-  aspect [command]
-
-Custom Commands from Plugins:
-  hello-world        Print 'Hello World!' to the command line.
-```
-
-## Releasing
-
-Just push a tag to your GitHub repo.
-The actions integration will create a release.
-
-[bazelisk]: https://bazel.build/install/bazelisk
-[aspect cli]: https://aspect.build/cli
-[plugin documentation]: https://docs.aspect.build/aspect-build/aspect-cli/5.0.1/docs/help/topics/plugins.html
-[aspect cli release]: https://github.com/aspect-build/aspect-cli/releases
+> TODO: Consider showing off your new plugin with a little animated demo of your terminal! We highly recommend [asciinema](https://asciinema.org).


### PR DESCRIPTION
This way it's not included in the plugin catalog